### PR TITLE
no-ud-id.xsl

### DIFF
--- a/htmlbook-xsl/no-us-id.xsl
+++ b/htmlbook-xsl/no-us-id.xsl
@@ -1,0 +1,27 @@
+<xsl:stylesheet version="1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns="http://www.w3.org/1999/xhtml"
+		>
+  <xsl:output method="xml"
+              encoding="UTF-8"/>
+  <xsl:preserve-space elements="*"/>
+  
+  <!-- prepend "xx" to ids starting with _  -->
+  <xsl:template match="@id[starts-with(.,'_')]">
+        <xsl:attribute name="id">xx<xsl:value-of select="."/></xsl:attribute>
+  </xsl:template>
+  <xsl:template match="@href[starts-with(.,'#_')]">
+        <xsl:variable name="frag" select="."/>
+        <xsl:attribute name="href">#xx<xsl:value-of select="substring($frag, 2)"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- Default Rule; when no other templates are specified, copy direct to output -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  
+</xsl:stylesheet> 


### PR DESCRIPTION
an xsl preprocessor that makes sure ids don't start with underscores. I
could go into Asciidoctor, and change it, but really "_" should be
allowed, it's just a epub compatibility issue.

adding a transformation step in the travis file will address https://github.com/GITenberg/Adventures-of-Huckleberry-Finn_76/issues/24
